### PR TITLE
Feature: Enable flag for not raise VM errors on RPC responses in ganache

### DIFF
--- a/docker/ganache/Dockerfile
+++ b/docker/ganache/Dockerfile
@@ -2,4 +2,4 @@ FROM node:9-alpine
 
 RUN npm install -g ganache-cli
 
-CMD ["ganache-cli", "-d", "--defaultBalanceEther", "10000", "-a", "10", "-h", "0.0.0.0"]
+CMD ["ganache-cli", "-d", "--defaultBalanceEther", "10000", "-a", "10", "-h", "0.0.0.0", "--noVMErrorsOnRPCResponse", "true"]


### PR DESCRIPTION
**Description**
In the near future, we will integrate the tx-history-service following the PersonalSafe contracts approach.

Used here: https://github.com/gnosis/safe-contracts/blob/development/contracts/GnosisSafePersonalEdition.sol#L164

For doing it successfully we have to enable the **--noVMErrorsOnRPCResponse** flag in ganache, otherwise when we calculate the process of calculating needed gas on inner safe transactions will fail